### PR TITLE
prep for v0.1.0 release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,12 @@ jobs:
         if [[ "${GITHUB_REF}" == "refs/tags/*" ]]; then
           # Release tags.
           echo IMAGE_TAG="${GITHUB_REF#refs/tags/}" >> $GITHUB_ENV
-          echo GORELEASER_ARGS="--clean --timeout=60m" >> $GITHUB_ENV
+          echo GORELEASER_ARGS="--clean --timeout=120m" >> $GITHUB_ENV
           echo ENABLE_RELEASE_PIPELINE=true >> $GITHUB_ENV
         elif [[ "${GITHUB_REF}" == "refs/heads/*" ]]; then
           # Branch build.
           echo IMAGE_TAG="$(echo "${GITHUB_REF#refs/heads/}" | sed -r 's|/+|-|g')" >> $GITHUB_ENV
-          echo GORELEASER_ARGS="--clean --skip-validate --timeout=60m" >> $GITHUB_ENV
+          echo GORELEASER_ARGS="--clean --skip-validate --timeout=120m" >> $GITHUB_ENV
         elif [[ "${GITHUB_REF}" == "refs/pull/*" ]]; then
           # PR build.
           echo IMAGE_TAG="pr-$(echo "${GITHUB_REF}" | sed -E 's|refs/pull/([^/]+)/?.*|\1|')" >> $GITHUB_ENV

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,5 +69,8 @@ docker_manifests:
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+changelog:
+  use: github-native
+  skip: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'
 release:
   disable: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'

--- a/Makefile
+++ b/Makefile
@@ -49,7 +49,7 @@ fix: ## Fixup files in the repo.
 	go mod tidy
 	go fmt ./...
 	make setup-lint
-	$(TOOLS_DIR)/golangci-lint run --fix --timeout=2m
+	$(TOOLS_DIR)/golangci-lint run --fix --timeout=5m
 
 .PHONY: setup-lint
 setup-lint: ## Setup the lint
@@ -175,7 +175,7 @@ goreleaser: $(LOCALBIN) ## Build a local copy of goreleaser
 	GOBIN=$(LOCALBIN) go install github.com/goreleaser/goreleaser@$(GORELEASER_VERSION)
 
 export ENABLE_RELEASE_PIPELINE ?= false
-export GORELEASER_ARGS         ?= --snapshot --clean --timeout=60m
+export GORELEASER_ARGS         ?= --snapshot --clean --timeout=120m
 release: IMAGE_TAG = $(GIT_VERSION)
 release: goreleaser ## Runs goreleaser. By default, this will run only as a snapshot and will not publish any artifacts unless it is run with different arguments. To override the arguments, run with "GORELEASER_ARGS=...". When run as a github action from a tag, this target will publish a full release.
 	$(GORELEASER) $(GORELEASER_ARGS)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/bash
 # This value must be updated to the release tag of the most recent release, a change that must
 # occur in the release commit. IMAGE_VERSION will be removed once each subproject that uses this
 # version is moved to a separate repo and release process.
-export IMAGE_VERSION = v0.0.0
+export IMAGE_VERSION = v0.1.0
 # Build-time variables to inject into binaries
 export SIMPLE_VERSION = $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,5 +28,5 @@ var (
 	// and release process, this variable will be removed.
 
 	// TODO: find a way to make this automated. For now manually update this before releases.
-	ImageVersion = "v0.0.0"
+	ImageVersion = "v0.1.0"
 )

--- a/testdata/memcached-molecule-operator/Makefile
+++ b/testdata/memcached-molecule-operator/Makefile
@@ -100,7 +100,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v0.0.0/ansible-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v0.1.0/ansible-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else


### PR DESCRIPTION
**Description of the change:**
- Update some version values to be v0.1.0 to prepare for the v0.1.0 release

**Motivation for the change:**
- Prepare to cut a v0.1.0 release

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/ansible-operator-plugins/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/ansible-operator-plugins/tree/master/website/content/en/docs)
