### PR TITLE
switch release image repo to quay.io/operator-framework/ansible-operator

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ export GO111MODULE = on
 export CGO_ENABLED = 0
 export PATH := $(PWD)/$(BUILD_DIR):$(PWD)/$(TOOLS_DIR):$(PATH)
 
-export IMAGE_REPO ?= quay.io/operator-framework/ansible-operator-plugins
+export IMAGE_REPO ?= quay.io/operator-framework/ansible-operator
 export IMAGE_TAG ?= dev
 
 ##@ Development
@@ -93,7 +93,7 @@ DOCKER_PROGRESS = --progress plain
 endif
 image/%: export DOCKER_CLI_EXPERIMENTAL = enabled
 image/%:
-	docker buildx build $(DOCKER_PROGRESS) -t $(BUILD_IMAGE_REPO)/$*-plugins:dev -f ./images/$*/Dockerfile --load . --no-cache
+	docker buildx build $(DOCKER_PROGRESS) -t $(BUILD_IMAGE_REPO)/$*:$(IMAGE_TAG) -f ./images/$*/Dockerfile --load . --no-cache
 ##@ Release
 
 ## TODO: Add release targets here

--- a/hack/generate/samples/ansible/advanced_molecule.go
+++ b/hack/generate/samples/ansible/advanced_molecule.go
@@ -201,8 +201,8 @@ func updateDockerfile(dir string) {
 	log.Info("replacing project Dockerfile to use ansible base image with the dev tag")
 	err := kbutil.ReplaceRegexInFile(
 		filepath.Join(dir, "Dockerfile"),
-		"quay.io/operator-framework/ansible-operator-plugins:.*",
-		"quay.io/operator-framework/ansible-operator-plugins:dev")
+		"quay.io/operator-framework/ansible-operator:.*",
+		"quay.io/operator-framework/ansible-operator:dev")
 	pkg.CheckError("replacing Dockerfile", err)
 
 	log.Info("inserting code to Dockerfile")

--- a/hack/generate/samples/ansible/memcached_molecule.go
+++ b/hack/generate/samples/ansible/memcached_molecule.go
@@ -77,7 +77,7 @@ func ImplementMemcachedMolecule(sample sample.Sample, image string) {
 	}
 
 	log.Info("replacing project Dockerfile to use ansible base image with the dev tag")
-	err := kbutil.ReplaceRegexInFile(filepath.Join(sample.Dir(), "Dockerfile"), "quay.io/operator-framework/ansible-operator-plugins:.*", "quay.io/operator-framework/ansible-operator-plugins:dev")
+	err := kbutil.ReplaceRegexInFile(filepath.Join(sample.Dir(), "Dockerfile"), "quay.io/operator-framework/ansible-operator:.*", "quay.io/operator-framework/ansible-operator:dev")
 	pkg.CheckError("replacing Dockerfile", err)
 
 	log.Info("adding RBAC permissions")

--- a/pkg/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
@@ -54,7 +54,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 	return nil
 }
 
-const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator-plugins:{{ .AnsibleOperatorVersion }}
+const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator:{{ .AnsibleOperatorVersion }}
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/testdata/memcached-molecule-operator/Dockerfile
+++ b/testdata/memcached-molecule-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator-plugins:dev
+FROM quay.io/operator-framework/ansible-operator:dev
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \


### PR DESCRIPTION
**Description of the change:**
- Switches the Quay image repository from `quay.io/operator-framework/ansible-operator-plugins` to `quay.io/operator-framework/ansible-operator` to prepare for the in-place swap in the Operator-SDK repository to using this plugin. This switch allows this repository to pick up the versioning where the Operator-SDK left off.

**Motivation for the change:**
- Prep for in place plugin switch within the Operator-SDK and prevent any user impacts or require any migrations