### PR TITLE
Update cr conditions

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,3 @@ Welcome to the Operator SDK! Before contributing, make sure to:
 **Motivation for the change:**
 
 
-**Checklist**
-
-If the pull request includes user-facing changes, extra documentation is required:
-- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/ansible-operator-plugins/tree/master/changelog/fragments/00-template.yaml))
-- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/ansible-operator-plugins/tree/master/website/content/en/docs)

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/bash
 # This value must be updated to the release tag of the most recent release, a change that must
 # occur in the release commit. IMAGE_VERSION will be removed once each subproject that uses this
 # version is moved to a separate repo and release process.
-export IMAGE_VERSION = v0.1.2
+export IMAGE_VERSION = v1.32.0
 # Build-time variables to inject into binaries
 export SIMPLE_VERSION = $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 export GIT_VERSION = $(shell git describe --dirty --tags --always)

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ export GO111MODULE = on
 export CGO_ENABLED = 0
 export PATH := $(PWD)/$(BUILD_DIR):$(PWD)/$(TOOLS_DIR):$(PATH)
 
-export IMAGE_REPO ?= quay.io/operator-framework/ansible-operator-plugins
+export IMAGE_REPO ?= quay.io/operator-framework/ansible-operator
 export IMAGE_TAG ?= dev
 
 ##@ Development
@@ -93,7 +93,7 @@ DOCKER_PROGRESS = --progress plain
 endif
 image/%: export DOCKER_CLI_EXPERIMENTAL = enabled
 image/%:
-	docker buildx build $(DOCKER_PROGRESS) -t $(BUILD_IMAGE_REPO)/$*-plugins:dev -f ./images/$*/Dockerfile --load . --no-cache
+	docker buildx build $(DOCKER_PROGRESS) -t $(BUILD_IMAGE_REPO)/$*:$(IMAGE_TAG) -f ./images/$*/Dockerfile --load . --no-cache
 ##@ Release
 
 ## TODO: Add release targets here

--- a/README.md
+++ b/README.md
@@ -1,2 +1,93 @@
 # ansible-operator-plugins
 Experimental extraction/refactoring of the Operator SDK's ansible operator plugin 
+
+
+# Releasing Guide
+
+## Pre-Requisites
+- Push access to this repository
+- Forked repository and local clone of fork
+- Remote ref named `upstream` that points to this repository
+
+## Release Prep (Applies to all releases)
+Since this project is currently consumed as a library there are some manual steps that need to take
+place prior to creating a release. They are as follows:
+1. Checkout the `main` branch:
+```sh
+git checkout main
+```
+2. Ensure the `main` branch is up to date:
+```sh
+git fetch upstream && git pull upstream main
+```
+3. Checkout a new branch for release prep work:
+```sh
+git checkout -b release/prep-vX.Y.Z
+```
+4. Update the `ImageVersion` variable in `internal/version/version.go` to be the version you are prepping for release
+5. Update the line with `export IMAGE_VERSION` in `Makefile` to be the version you are prepping for release
+6. Regenerate the testdata:
+```sh
+make generate
+```
+7. Commit and push your changes to your fork
+8. Create a PR against the `main` branch
+
+## Creating Major/Minor Releases
+1. Ensure the steps in [Release Prep](#release-prep-applies-to-all-releases) have been completed. Do **NOT** progress past this point until the release prep PR has merged.
+2. Checkout the `main` branch:
+```sh
+git checkout main
+```
+3. Ensure your local branch is up to date:
+```sh
+git fetch upstream && git pull upstream main
+```
+4. Checkout a new branch for the new release following the pattern `release-vX.Y`. In this example we will create a branch for a `v0.2.0` release:
+```sh
+git checkout -b release-v0.2
+```
+5. Push the newly created release branch:
+```sh
+git push -u upstream release-v0.2
+```
+6. Create a new release tag:
+```sh
+git tag -a -s -m "ansible-operator-plugins release v0.2.0" v0.2.0
+```
+7. Push the new tag:
+```sh
+git push upstream v0.2.0
+```
+
+## Creating Patch Releases
+1. Ensure the steps in [Release Prep](#release-prep-applies-to-all-releases) have been completed. Do **NOT** progress past this point until the release prep PR has merged.
+2. Cherry pick the merged release prep PR to the proper major/minor branch by commenting the following on the PR:
+```
+/cherry-pick release-vX.Y
+```
+where X is the major version and Y is the minor version. An example of cherry picking for a `v0.2.1` release would be:
+```
+/cherry-pick release-v0.2
+```
+3. A bot will have created the cherry pick PR. Merge this. Do **NOT** progress past this point until the cherry pick PR has merged.
+4. Checkout the appropriate release branch. In this example we will be "creating" a `v0.2.1` release:
+```sh
+git checkout release-v0.2
+```
+5. Ensure it is up to date:
+```sh
+git fetch upstream && git pull upstream release-v0.2
+```
+6. Create a new release tag:
+```sh
+git tag -a -s -m "ansible-operator-plugins release v0.2.1" v0.2.1
+```
+7. Push the new tag:
+```sh
+git push upstream v0.2.1
+```
+
+> [!NOTE]
+> While the release process is automated once the tag is pushed it can occasionally timeout.
+> If this happens, re-running the action will re-run the release process and typically succeed.

--- a/hack/generate/samples/ansible/advanced_molecule.go
+++ b/hack/generate/samples/ansible/advanced_molecule.go
@@ -201,8 +201,8 @@ func updateDockerfile(dir string) {
 	log.Info("replacing project Dockerfile to use ansible base image with the dev tag")
 	err := kbutil.ReplaceRegexInFile(
 		filepath.Join(dir, "Dockerfile"),
-		"quay.io/operator-framework/ansible-operator-plugins:.*",
-		"quay.io/operator-framework/ansible-operator-plugins:dev")
+		"quay.io/operator-framework/ansible-operator:.*",
+		"quay.io/operator-framework/ansible-operator:dev")
 	pkg.CheckError("replacing Dockerfile", err)
 
 	log.Info("inserting code to Dockerfile")

--- a/hack/generate/samples/ansible/memcached_molecule.go
+++ b/hack/generate/samples/ansible/memcached_molecule.go
@@ -77,7 +77,7 @@ func ImplementMemcachedMolecule(sample sample.Sample, image string) {
 	}
 
 	log.Info("replacing project Dockerfile to use ansible base image with the dev tag")
-	err := kbutil.ReplaceRegexInFile(filepath.Join(sample.Dir(), "Dockerfile"), "quay.io/operator-framework/ansible-operator-plugins:.*", "quay.io/operator-framework/ansible-operator-plugins:dev")
+	err := kbutil.ReplaceRegexInFile(filepath.Join(sample.Dir(), "Dockerfile"), "quay.io/operator-framework/ansible-operator:.*", "quay.io/operator-framework/ansible-operator:dev")
 	pkg.CheckError("replacing Dockerfile", err)
 
 	log.Info("adding RBAC permissions")

--- a/internal/ansible/controller/reconcile.go
+++ b/internal/ansible/controller/reconcile.go
@@ -302,11 +302,6 @@ func (r *AnsibleOperatorReconciler) markRunning(ctx context.Context, nn types.Na
 	crStatus := getStatus(u)
 
 	// If there is no current status add that we are working on this resource.
-	errCond := ansiblestatus.GetCondition(crStatus, ansiblestatus.FailureConditionType)
-	if errCond != nil {
-		errCond.Status = v1.ConditionFalse
-		ansiblestatus.SetCondition(&crStatus, *errCond)
-	}
 	successCond := ansiblestatus.GetCondition(crStatus, ansiblestatus.SuccessfulConditionType)
 	if successCond != nil {
 		successCond.Status = v1.ConditionFalse

--- a/internal/ansible/controller/status/utils_test.go
+++ b/internal/ansible/controller/status/utils_test.go
@@ -96,7 +96,7 @@ func TestGetCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -110,7 +110,7 @@ func TestGetCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -122,7 +122,7 @@ func TestGetCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -136,7 +136,7 @@ func TestGetCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -167,7 +167,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -179,7 +179,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: RunningConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -191,7 +191,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: FailureConditionType,
 					},
 				},
@@ -203,7 +203,7 @@ func TestRemoveCondition(t *testing.T) {
 			condType: FailureConditionType,
 			status: Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type: RunningConditionType,
 					},
 				},
@@ -247,7 +247,7 @@ func TestSetCondition(t *testing.T) {
 			name: "update running condition",
 			status: &Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type:               RunningConditionType,
 						Status:             v1.ConditionTrue,
 						Reason:             SuccessfulReason,
@@ -264,7 +264,7 @@ func TestSetCondition(t *testing.T) {
 			name: "do not update running condition",
 			status: &Status{
 				Conditions: []Condition{
-					Condition{
+					{
 						Type:               RunningConditionType,
 						Status:             v1.ConditionTrue,
 						Reason:             RunningReason,

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,5 +28,5 @@ var (
 	// and release process, this variable will be removed.
 
 	// TODO: find a way to make this automated. For now manually update this before releases.
-	ImageVersion = "v0.1.2"
+	ImageVersion = "v1.32.0"
 )

--- a/pkg/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
+++ b/pkg/plugins/ansible/v1/scaffolds/internal/templates/dockerfile.go
@@ -54,7 +54,7 @@ func (f *Dockerfile) SetTemplateDefaults() error {
 	return nil
 }
 
-const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator-plugins:{{ .AnsibleOperatorVersion }}
+const dockerfileTemplate = `FROM quay.io/operator-framework/ansible-operator:{{ .AnsibleOperatorVersion }}
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/testdata/memcached-molecule-operator/Dockerfile
+++ b/testdata/memcached-molecule-operator/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/operator-framework/ansible-operator-plugins:dev
+FROM quay.io/operator-framework/ansible-operator:dev
 
 COPY requirements.yml ${HOME}/requirements.yml
 RUN ansible-galaxy collection install -r ${HOME}/requirements.yml \

--- a/testdata/memcached-molecule-operator/Makefile
+++ b/testdata/memcached-molecule-operator/Makefile
@@ -100,7 +100,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v0.1.2/ansible-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v1.32.0/ansible-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/operator-sdk/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Given it is possible for a custom resource to be in error / failed state while a new reconcile process is ongoing, it is unnecessary to mark the status of previous Failure conditions to `False` while the reconcile loop is still running.

The failure condition will be removed when the custom resource is successfully deployed as it works today.

**Motivation for the change:**

The failure conditions have timestamps and are accurate as at the time of reporting. Therefore, it would be unnecessary and misleading to set the failure condition status to `False` before the custom resource is successfully deployed.

**Checklist**

If the pull request includes user-facing changes, extra documentation is required:
- [x] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/operator-sdk/tree/master/changelog/fragments/00-template.yaml))
- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/operator-sdk/tree/master/website/content/en/docs)