### PR TITLE
Remove pull request checklist

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -18,8 +18,3 @@ Welcome to the Operator SDK! Before contributing, make sure to:
 **Motivation for the change:**
 
 
-**Checklist**
-
-If the pull request includes user-facing changes, extra documentation is required:
-- [ ] Add a new changelog fragment in `changelog/fragments` (see [`changelog/fragments/00-template.yaml`](https://github.com/operator-framework/ansible-operator-plugins/tree/master/changelog/fragments/00-template.yaml))
-- [ ] Add or update relevant sections of the docs website in [`website/content/en/docs`](https://github.com/operator-framework/ansible-operator-plugins/tree/master/website/content/en/docs)


### PR DESCRIPTION
Changelogs will be generated from git commits while documentation will still be contained in the main Operator SDK repository

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Update the pull request checklist for the ansible-operator-plugins repository

**Motivation for the change:**

 Changelogs will be generated by `goreleaser` from git commits while documentation will still be contained in the main Operator SDK repository.
    
Closes #15 
