### PR TITLE
(release): prep for v1.33.0 release

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -69,6 +69,9 @@ docker_manifests:
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-arm64"
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-ppc64le"
     - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-s390x"
+archives:
+  - format: binary
+    name_template: "{{ .Binary }}_{{ .Os }}_{{ .Arch }}"
 changelog:
   use: github-native
   skip: '{{ ne .Env.ENABLE_RELEASE_PIPELINE "true" }}'

--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SHELL = /bin/bash
 # This value must be updated to the release tag of the most recent release, a change that must
 # occur in the release commit. IMAGE_VERSION will be removed once each subproject that uses this
 # version is moved to a separate repo and release process.
-export IMAGE_VERSION = v1.32.0
+export IMAGE_VERSION = v1.33.0
 # Build-time variables to inject into binaries
 export SIMPLE_VERSION := $(shell (test "$(shell git describe --tags)" = "$(shell git describe --tags --abbrev=0)" && echo $(shell git describe --tags)) || echo $(shell git describe --tags --abbrev=0)+git)
 export GIT_VERSION := $(shell git describe --dirty --tags --always)

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -28,5 +28,5 @@ var (
 	// and release process, this variable will be removed.
 
 	// TODO: find a way to make this automated. For now manually update this before releases.
-	ImageVersion = "v1.32.0"
+	ImageVersion = "v1.33.0"
 )

--- a/testdata/memcached-molecule-operator/Makefile
+++ b/testdata/memcached-molecule-operator/Makefile
@@ -100,7 +100,7 @@ ifeq (,$(shell which ansible-operator 2>/dev/null))
 	@{ \
 	set -e ;\
 	mkdir -p $(dir $(ANSIBLE_OPERATOR)) ;\
-	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v1.32.0/ansible-operator_$(OS)_$(ARCH) ;\
+	curl -sSLo $(ANSIBLE_OPERATOR) https://github.com/operator-framework/ansible-operator-plugins/releases/download/v1.33.0/ansible-operator_$(OS)_$(ARCH) ;\
 	chmod +x $(ANSIBLE_OPERATOR) ;\
 	}
 else


### PR DESCRIPTION
**Description of the change:**
- Update versions to prepare for the v1.33.0 release
- Updates the goreleaser config to fix #36 

**Motivation for the change:**
- Prepare for the v1.33.0 release

