### PR TITLE
replace all ${VAR} references with env var values in watches yaml

### DIFF
--- a/internal/ansible/watches/testdata/env-vars.yaml
+++ b/internal/ansible/watches/testdata/env-vars.yaml
@@ -1,0 +1,11 @@
+---
+- version: "${WATCH_VERSION}"
+  group: "app.example.com"
+  kind: "AnsibleSelectorTest"
+  playbook: ${WATCH_PLAYBOOK}
+  selector:
+    matchLabels:
+      ${WATCH_MATCH_LABEL_VAR_NAME}: "${WATCH_MATCH_LABEL_VAR_VALUE}"
+      undefined: "${WATCH_UNDEFINED_ENV_VAR}"
+    matchExpressions:
+      - {key: ${WATCH_MATCH_EXPRESSIONS_KEY}, operator: In, values: [a, b]}

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -901,16 +901,11 @@ func TestReplaceEnvVars(t *testing.T) { //nolint:gocyclo
 	watchesFile := filepath.Join(cwd, "testdata", "env-vars.yaml")
 	playbookFile := filepath.Join(cwd, "testdata", "playbook.yml")
 
-	os.Setenv("WATCH_PLAYBOOK", playbookFile)
-	defer os.Unsetenv("WATCH_PLAYBOOK")
-	os.Setenv("WATCH_VERSION", "v123")
-	defer os.Unsetenv("WATCH_VERSION")
-	os.Setenv("WATCH_MATCH_LABEL_VAR_NAME", "label123")
-	defer os.Unsetenv("WATCH_MATCH_LABEL_VAR_NAME")
-	os.Setenv("WATCH_MATCH_LABEL_VAR_VALUE", "value123")
-	defer os.Unsetenv("WATCH_MATCH_LABEL_VAR_VALUE")
-	os.Setenv("WATCH_MATCH_EXPRESSIONS_KEY", "key123")
-	defer os.Unsetenv("WATCH_MATCH_EXPRESSIONS_KEY")
+	t.Setenv("WATCH_PLAYBOOK", playbookFile)
+	t.Setenv("WATCH_VERSION", "v123")
+	t.Setenv("WATCH_MATCH_LABEL_VAR_NAME", "label123")
+	t.Setenv("WATCH_MATCH_LABEL_VAR_VALUE", "value123")
+	t.Setenv("WATCH_MATCH_EXPRESSIONS_KEY", "key123")
 
 	watchSlice, err := Load(watchesFile, 1, 1)
 	if err != nil {

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -892,3 +892,49 @@ func TestGetPossibleRolePaths(t *testing.T) {
 		})
 	}
 }
+
+func TestReplaceEnvVars(t *testing.T) { //nolint:gocyclo
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Unable to get working directory: %v", err)
+	}
+	watchesFile := filepath.Join(cwd, "testdata", "env-vars.yaml")
+	playbookFile := filepath.Join(cwd, "testdata", "playbook.yml")
+
+	os.Setenv("WATCH_PLAYBOOK", playbookFile)
+	defer os.Unsetenv("WATCH_PLAYBOOK")
+	os.Setenv("WATCH_VERSION", "v123")
+	defer os.Unsetenv("WATCH_VERSION")
+	os.Setenv("WATCH_MATCH_LABEL_VAR_NAME", "label123")
+	defer os.Unsetenv("WATCH_MATCH_LABEL_VAR_NAME")
+	os.Setenv("WATCH_MATCH_LABEL_VAR_VALUE", "value123")
+	defer os.Unsetenv("WATCH_MATCH_LABEL_VAR_VALUE")
+	os.Setenv("WATCH_MATCH_EXPRESSIONS_KEY", "key123")
+	defer os.Unsetenv("WATCH_MATCH_EXPRESSIONS_KEY")
+
+	watchSlice, err := Load(watchesFile, 1, 1)
+	if err != nil {
+		// this would fail if the WATCH_PLAYBOOK env var wasn't replaced
+		t.Fatalf("Failed to process watches yaml with env vars: %v", err)
+	}
+	if watchSlice[0].GroupVersionKind.Group != "app.example.com" {
+		t.Fatalf("Failed to parse hardcoded group - the watches yaml did not load properly: %+v", watchSlice[0])
+	}
+	if watchSlice[0].GroupVersionKind.Version != "v123" {
+		t.Fatalf("Failed to replace version with env var: %+v", watchSlice[0])
+	}
+	if labelValue, ok := watchSlice[0].Selector.MatchLabels["label123"]; !ok {
+		t.Fatalf("Failed to replace first match label name with env var: %+v", watchSlice[0])
+	} else if labelValue != "value123" {
+		t.Fatalf("Failed to replace first match label value with env var: %+v", watchSlice[0])
+	}
+	if labelValue, ok := watchSlice[0].Selector.MatchLabels["undefined"]; !ok {
+		t.Fatalf("Failed to find the second match label name: %+v", watchSlice[0])
+	} else if labelValue != "${WATCH_UNDEFINED_ENV_VAR}" {
+		t.Fatalf("Failed to keep env var reference as-is: %+v", watchSlice[0])
+	}
+	keyValue := watchSlice[0].Selector.MatchExpressions[0].Key
+	if keyValue != "key123" {
+		t.Fatalf("Failed to replace match expression key with env var: %+v", watchSlice[0])
+	}
+}

--- a/internal/ansible/watches/watches_test.go
+++ b/internal/ansible/watches/watches_test.go
@@ -893,7 +893,7 @@ func TestGetPossibleRolePaths(t *testing.T) {
 	}
 }
 
-func TestReplaceEnvVars(t *testing.T) { //nolint:gocyclo
+func TestReplaceEnvVars(t *testing.T) {
 	cwd, err := os.Getwd()
 	if err != nil {
 		t.Fatalf("Unable to get working directory: %v", err)


### PR DESCRIPTION
**Description of the change:**

For any ${VAR} references in the watches yaml, this replaces those env vars with their values before the watches yaml is processed. If there is no ${VAR} defined, the "${VAR}" remains as-is in the watches yaml.

**Motivation for the change:**

There are times when a user wants to customize what an operator will watch. Right now, watches.yaml is fixed and cannot be customized or configured. This feature at least allows the operator to be somewhat configurable by passing in env vars in the operator's subscription or directly in its Deployment.

For one such example, I may have an operator that can be deployed on OpenShift and non-OpenShift environments. I therefore could have two different sets of playbooks in my operator container - one for OpenShift and one for non-OpenShift. I could define a set of ${WATCH_PLAYBOOK_XYZ} env vars and point to cluster-specific playbooks in the watches.yaml:
```yaml
- version: v1
  group: bar.example.com
  kind: Bar
  playbook: ${WATCH_PLAYBOOK_BAR}
```
When deployed on OpenShift, my OLM CSV could define that env var to "playbook-bar-openshift.yml" and on non-OpenShift, I have its OLM CSV define the env var to "playbook-bar-kubernetes.yml".

Another example. I want my operator to watch Bar objects, but I do NOT want the operator to run my playbook reconciliation on every Bar in the cluster - I only want to run a reconciliation when a Bar with a specific selector. But! (and here's the important part), this selector can be different depending on what the admin wants (the admin being the person who installed the operator). With this PR, this can be accomplished like this:

[watches.yaml](https://sdk.operatorframework.io/docs/building-operators/ansible/reference/watches/):
```yaml
- version: v1
  group: bar.example.com
  kind: Bar
  playbook: playbook.yml
  selector:
    matchLabels:
      ${SPECIAL_BAR_NAME}: ${SPECIAL_BAR_VAL}
```

Operator Subscription:

```yaml
kind: Subscription
metadata:
  name: my-operator
spec:
  package: my-operator
  channel: stable
  config:
    env:
    - name: SPECIAL_BAR_NAME
      value: "special-bar-name"
    - name: SPECIAL_BAR_VAL
      value: "special-bar-value"
```

