### PR TITLE
Fix initiliazation of new projects

### DIFF
--- a/pkg/plugins/util/cleanup.go
+++ b/pkg/plugins/util/cleanup.go
@@ -62,26 +62,17 @@ func RemoveKustomizeCRDManifests() error {
 func UpdateKustomizationsInit() error {
 
 	defaultKFile := filepath.Join("config", "default", "kustomization.yaml")
-	if err := kbutil.ReplaceInFile(defaultKFile,
-		`
-# [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
-# crd/kustomization.yaml
-#- ../webhook
-# [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'. 'WEBHOOK' components are required.
-#- ../certmanager`, ""); err != nil {
-		return fmt.Errorf("remove %s resources: %v", defaultKFile, err)
-	}
 
 	if err := kbutil.ReplaceInFile(defaultKFile,
 		`
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+#- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

Fixes a bug where we try to search-and-remove some boilerplate that have changed upstream.

**Motivation for the change:**

Attempting to initialize new operator project is not possible as you get the below error message:

```
INFO[0000] Writing kustomize manifests for you to edit...
Error: failed to initialize project: unable to scaffold with "base.ansible.sdk.operatorframework.io/v1": error updating init manifests: error updating kustomization.yaml files: remove config/default/kustomization.yaml patch and vars blocks: unable to find the content to be replaced
Usage:
  operator-sdk init [flags]

Examples:

  # Scaffold a project with no API
  $ operator-sdk init --plugins=base.ansible.sdk.operatorframework.io/v1 --domain=my.domain \

  # Invokes "create api"
  $ operator-sdk init --plugins=base.ansible.sdk.operatorframework.io/v1 \
      --domain=my.domain \
      --group=apps --version=v1alpha1 --kind=AppService

  $ operator-sdk init --plugins=base.ansible.sdk.operatorframework.io/v1 \
      --domain=my.domain \
      --group=apps --version=v1alpha1 --kind=AppService \
      --generate-role

  $ operator-sdk init --plugins=base.ansible.sdk.operatorframework.io/v1 \
      --domain=my.domain \
      --group=apps --version=v1alpha1 --kind=AppService \
      --generate-playbook

  $ operator-sdk init --plugins=base.ansible.sdk.operatorframework.io/v1 \
      --domain=my.domain \
      --group=apps --version=v1alpha1 --kind=AppService \
      --generate-playbook \
      --generate-role


Flags:
      --project-version string   project version (default "3")
      --domain string            domain for groups (default "my.domain")
      --project-name string      name of this project
      --group string             resource Group
      --version string           resource Version
      --kind string              resource Kind
      --generate-role            Generate an Ansible role skeleton.
      --generate-playbook        Generate an Ansible playbook. If passed with --generate-role, the playbook will invoke the role.
  -h, --help                     help for init

Global Flags:
      --plugins strings   plugin keys to be used for this subcommand execution
      --verbose           Enable verbose logging

FATA[0000] failed to initialize project: unable to scaffold with "base.ansible.sdk.operatorframework.io/v1": error updating init manifests: error updating kustomization.yaml files: remove config/default/kustomization.yaml patch and vars blocks: unable to find the content to be replaced
```
