### PR TITLE
in case of failure, we want to update the error to latest run

### DIFF
--- a/internal/ansible/controller/status/utils.go
+++ b/internal/ansible/controller/status/utils.go
@@ -67,7 +67,7 @@ func GetCondition(status Status, condType ConditionType) *Condition {
 // we are about to add already exists and has the same status and reason then we are not going to update.
 func SetCondition(status *Status, condition Condition) {
 	currentCond := GetCondition(*status, condition.Type)
-	if currentCond != nil && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
+	if currentCond != nil && condition.Type != FailureConditionType && currentCond.Status == condition.Status && currentCond.Reason == condition.Reason {
 		return
 	}
 	// Do not update lastTransitionTime if the status of the condition doesn't change.

--- a/internal/ansible/controller/status/utils_test.go
+++ b/internal/ansible/controller/status/utils_test.go
@@ -278,6 +278,24 @@ func TestSetCondition(t *testing.T) {
 			keepLastTransitionTime: true,
 			keepMessage:            true,
 		},
+		{
+			name: "on failure, always update error message",
+			status: &Status{
+				Conditions: []Condition{
+					{
+						Type:               FailureConditionType,
+						Status:             v1.ConditionTrue,
+						Reason:             FailedReason,
+						Message:            "Previous failure",
+						LastTransitionTime: lastTransitionTime,
+					},
+				},
+			},
+			condition:              NewCondition(FailureConditionType, v1.ConditionTrue, nil, FailedReason, "New failure"),
+			expectedNewSize:        1,
+			keepLastTransitionTime: true,
+			keepMessage:            false,
+		},
 	}
 
 	for _, tc := range testCases {


### PR DESCRIPTION
Its required for status to continue to update its message, despite the playbook remaining in a Failure mode.

Without this, the admin only sees the first error that the playbook met, and never see any new errors than happens has more reconciles continue to fail on distinct steps.
