### PR TITLE
mark unsafe the non-spec obj parameter

### DIFF
--- a/internal/ansible/runner/runner.go
+++ b/internal/ansible/runner/runner.go
@@ -366,6 +366,7 @@ func (r *runner) makeParameters(u *unstructured.Unstructured) map[string]interfa
 	specKey := fmt.Sprintf("%s_spec", objKey)
 	parameters[specKey] = spec
 	if r.markUnsafe {
+		parameters[objKey] = markUnsafe(u.Object)
 		parameters[specKey] = markUnsafe(spec)
 	}
 


### PR DESCRIPTION
There are two magic variables in ansible-operator, one for the `_spec` and containing the whole object. If we have some jinja syntax in the annotations or in the status, `markUnsafe` currently misses it and it fails when injecting the variable in the playbook/role.