### PR TITLE
bump kubebuilder to v3.13.0 and fixup scaffolding

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,7 +26,7 @@ require (
 	k8s.io/kubectl v0.28.5
 	k8s.io/utils v0.0.0-20240102154912-e7106e64919e
 	sigs.k8s.io/controller-runtime v0.16.3
-	sigs.k8s.io/kubebuilder/v3 v3.12.0
+	sigs.k8s.io/kubebuilder/v3 v3.13.0
 	sigs.k8s.io/yaml v1.4.0
 )
 

--- a/go.sum
+++ b/go.sum
@@ -454,8 +454,8 @@ sigs.k8s.io/controller-runtime v0.16.3 h1:2TuvuokmfXvDUamSx1SuAOO3eTyye+47mJCigw
 sigs.k8s.io/controller-runtime v0.16.3/go.mod h1:j7bialYoSn142nv9sCOJmQgDXQXxnroFU4VnX/brVJ0=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd h1:EDPBXCAspyGV4jQlpZSudPeMmr1bNJefnuqLsRAsHZo=
 sigs.k8s.io/json v0.0.0-20221116044647-bc3834ca7abd/go.mod h1:B8JuhiUyNFVKdsE8h686QcCxMaH6HrOAZj4vswFpcB0=
-sigs.k8s.io/kubebuilder/v3 v3.12.0 h1:POh46v+T2wPGzAzcIE/eKlwZr17nn+R49elJg2Wz2qU=
-sigs.k8s.io/kubebuilder/v3 v3.12.0/go.mod h1:ZJZ6jpjhh0skfehrYl7b8X/SCozhfLAU7IYV8ZN/f3s=
+sigs.k8s.io/kubebuilder/v3 v3.13.0 h1:ft1r2HdI29hEgtbuk3AEjOGX5A0N3jjbSA54oZzXH5I=
+sigs.k8s.io/kubebuilder/v3 v3.13.0/go.mod h1:BA3wwWd7P31jNLH9x+l5TzK6Of61SwY469ChO1+G2Cc=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3 h1:PRbqxJClWWYMNV1dhaG4NsibJbArud9kFxnAMREiWFE=
 sigs.k8s.io/structured-merge-diff/v4 v4.2.3/go.mod h1:qjx8mGObPmV2aSZepjQjbmb2ihdVs8cGKBraizNC69E=
 sigs.k8s.io/yaml v1.4.0 h1:Mk1wCc2gy/F0THH0TAp1QYyJNzRm2KCLy3o5ASXVI5E=

--- a/hack/generate/samples/ansible/advanced_molecule.go
+++ b/hack/generate/samples/ansible/advanced_molecule.go
@@ -75,10 +75,6 @@ func ImplementAdvancedMolecule(sample sample.Sample, image string) {
 	addMocksFromTestdata(sample.Dir(), sample.CommandContext())
 	updateDockerfile(sample.Dir())
 	updateConfig(sample.Dir())
-
-	// Replace kustomize version to v5.2.1 to enable running the
-	// tests on a mac with Apple Silicon
-	replaceKustomizeVersion(sample.Dir(), "v5.2.1")
 }
 
 func updateConfig(dir string) {

--- a/hack/generate/samples/ansible/memcached.go
+++ b/hack/generate/samples/ansible/memcached.go
@@ -73,12 +73,3 @@ func addingAnsibleTask(dir string, gvk schema.GroupVersionKind) {
 		"# TODO(user): Add fields here", "size: 1")
 	pkg.CheckError("updating sample CR", err)
 }
-
-// replaceKustomizeVersion will replace the kustomize version used in the
-// Makefile to the version specified
-func replaceKustomizeVersion(dir string, version string) {
-	err := kbutil.ReplaceInFile(filepath.Join(dir, "Makefile"),
-		"curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/v5.1.1/kustomize_v5.1.1_$(OS)_$(ARCH).tar.gz | \\",
-		fmt.Sprintf("curl -sSLo - https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize/%s/kustomize_%s_$(OS)_$(ARCH).tar.gz | \\", version, version))
-	pkg.CheckError(fmt.Sprintf("replacing kustomize version to %s", version), err)
-}

--- a/hack/generate/samples/ansible/memcached.go
+++ b/hack/generate/samples/ansible/memcached.go
@@ -40,10 +40,6 @@ func ImplementMemcached(sample sample.Sample, image string) {
 			addingMoleculeMockData(sample.Dir(), sample.Name(), gvk)
 		}
 	}
-
-	// Replace kustomize version to v5.2.1 to enable running the
-	// tests on a mac with Apple Silicon
-	replaceKustomizeVersion(sample.Dir(), "v5.2.1")
 }
 
 // addingMoleculeMockData will customize the molecule data

--- a/hack/tests/e2e-ansible-molecule.sh
+++ b/hack/tests/e2e-ansible-molecule.sh
@@ -30,9 +30,10 @@ pip3 install pyasn1==0.4.7 pyasn1-modules==0.2.6 idna==2.8 ipaddress==1.0.23
 pip3 install cryptography molecule==5.1.0
 pip3 install ansible-lint yamllint
 pip3 install docker kubernetes jmespath
+pip3 install requests==2.32.2
 ansible-galaxy collection install 'kubernetes.core:==2.4.0'
 ansible-galaxy collection install 'operator_sdk.util:==0.4.0'
-ansible-galaxy collection install 'community.docker:==3.4.0'
+ansible-galaxy collection install 'community.docker:==3.10.3'
 
 header_text "Copying molecule testdata scenarios"
 ROOTDIR="$(pwd)"

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -25,7 +25,12 @@ RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
   && pip3 install --upgrade pip~=23.3.2 \
   && pip3 install pipenv==2023.11.15 \
   && pipenv install --deploy \
-  && pipenv check \
+  # NOTE: This ignored vulnerability (70612) was detected in jinja2, \
+  # but the vulnerability is disputed and may never be fixed. See: \
+  #  - https://github.com/advisories/GHSA-f6pv-j8mr-w6rr \
+  #  - https://github.com/dbt-labs/dbt-core/issues/10250 \
+  #  - https://data.safetycli.com/v/70612/97c/ \
+  && pipenv check --ignore 70612 \
   && yum remove -y gcc libffi-devel openssl-devel python39-devel \
   && yum clean all \
   && rm -rf /var/cache/yum

--- a/images/ansible-operator/pipfile.Dockerfile
+++ b/images/ansible-operator/pipfile.Dockerfile
@@ -21,7 +21,12 @@ RUN set -e && yum clean all && rm -rf /var/cache/yum/* \
   && pip3 install --upgrade pip~=23.3.2 \
   && pip3 install pipenv==2023.11.15 \
   && pipenv lock \
-  && pipenv check \
+  # NOTE: This ignored vulnerability (70612) was detected in jinja2, \
+  # but the vulnerability is disputed and may never be fixed. See: \
+  #  - https://github.com/advisories/GHSA-f6pv-j8mr-w6rr \
+  #  - https://github.com/dbt-labs/dbt-core/issues/10250 \
+  #  - https://data.safetycli.com/v/70612/97c/ \
+  && pipenv check --ignore 70612 \
   && yum remove -y gcc libffi-devel openssl-devel python39-devel \
   && yum clean all \
   && rm -rf /var/cache/yum

--- a/pkg/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/role.go
+++ b/pkg/plugins/ansible/v1/scaffolds/internal/templates/config/rbac/role.go
@@ -39,6 +39,7 @@ func (f *ManagerRole) SetTemplateDefaults() error {
 	}
 
 	f.TemplateBody = fmt.Sprintf(roleTemplate, machinery.NewMarkerFor(f.Path, rulesMarker))
+	f.IfExistsAction = machinery.OverwriteFile
 
 	return nil
 }

--- a/pkg/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
+++ b/pkg/plugins/ansible/v1/scaffolds/internal/templates/requirements.go
@@ -42,5 +42,5 @@ collections:
   - name: cloud.common
     version: "2.1.1"
   - name: community.docker
-    version: "3.4.5"
+    version: "3.10.3"
 `

--- a/pkg/plugins/util/cleanup.go
+++ b/pkg/plugins/util/cleanup.go
@@ -76,12 +76,12 @@ func UpdateKustomizationsInit() error {
 		`
 # [WEBHOOK] To enable webhook, uncomment all the sections with [WEBHOOK] prefix including the one in
 # crd/kustomization.yaml
-#- manager_webhook_patch.yaml
+#- path: manager_webhook_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER'.
 # Uncomment 'CERTMANAGER' sections in crd/kustomization.yaml to enable the CA injection in the admission webhooks.
 # 'CERTMANAGER' needs to be enabled to use ca injection
-#- webhookcainjection_patch.yaml
+#- path: webhookcainjection_patch.yaml
 
 # [CERTMANAGER] To enable cert-manager, uncomment all sections with 'CERTMANAGER' prefix.
 # Uncomment the following replacements to add the cert-manager CA injection annotations

--- a/testdata/memcached-molecule-operator/config/default/kustomization.yaml
+++ b/testdata/memcached-molecule-operator/config/default/kustomization.yaml
@@ -21,10 +21,8 @@ resources:
 # [PROMETHEUS] To enable prometheus monitor, uncomment all sections with 'PROMETHEUS'.
 - ../prometheus
 
-patchesStrategicMerge:
+patches:
 # Protect the /metrics endpoint by putting it behind auth.
 # If you want your controller-manager to expose the /metrics
 # endpoint w/o any authn/z, please comment the following line.
-- manager_auth_proxy_patch.yaml
-
-
+- path: manager_auth_proxy_patch.yaml

--- a/testdata/memcached-molecule-operator/config/default/manager_auth_proxy_patch.yaml
+++ b/testdata/memcached-molecule-operator/config/default/manager_auth_proxy_patch.yaml
@@ -14,8 +14,8 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
-        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.14.1
+            - "ALL"
+        image: gcr.io/kubebuilder/kube-rbac-proxy:v0.15.0
         args:
         - "--secure-listen-address=0.0.0.0:8443"
         - "--upstream=http://127.0.0.1:8080/"

--- a/testdata/memcached-molecule-operator/config/manager/manager.yaml
+++ b/testdata/memcached-molecule-operator/config/manager/manager.yaml
@@ -78,7 +78,7 @@ spec:
           allowPrivilegeEscalation: false
           capabilities:
             drop:
-              - "ALL"
+            - "ALL"
         livenessProbe:
           httpGet:
             path: /healthz

--- a/testdata/memcached-molecule-operator/config/prometheus/monitor.yaml
+++ b/testdata/memcached-molecule-operator/config/prometheus/monitor.yaml
@@ -1,4 +1,3 @@
-
 # Prometheus Monitor Service (Metrics)
 apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor

--- a/testdata/memcached-molecule-operator/requirements.yml
+++ b/testdata/memcached-molecule-operator/requirements.yml
@@ -7,4 +7,4 @@ collections:
   - name: cloud.common
     version: "2.1.1"
   - name: community.docker
-    version: "3.4.5"
+    version: "3.10.3"


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
Bump Kubebuilder to v3.13.0 and fix up scaffolding to handle the incoming breaking changes.

**Motivation for the change:**
Operator SDK already bumped its kubebuilder dependency to v3.13.0, but it still uses a version of this package that is on a prior version.

Kubebuilder 3.13.0 seems to have made some changes in its `kustomize` plugin that break the expectations of downstream plugins (like this one)

In order to fix things up, we need to _also_ bump this repo to Kubebuilder v3.13.0, fix up its scaffolding to handle the incoming breaking changes, make a release, and then bump operator-sdk.

This PR is the first step of the process.
