### PR TITLE
enables ansible-operator binary build in dockerfile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,9 +86,9 @@ build/ansible-operator:
 ##@ Dev image build
 
 # Convenience wrapper for building all remotely hosted images.
-.PHONY: image-build
 IMAGE_TARGET_LIST = ansible-operator
-image-build: build $(foreach i,$(IMAGE_TARGET_LIST),image/$(i)) ## Build all images.
+image-build: BUILD_GOOS=linux
+image-build: build $(foreach i,$(IMAGE_TARGET_LIST), image/$(i)) ## Build all images.
 
 # Build an image.
 BUILD_IMAGE_REPO = quay.io/operator-framework

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -83,6 +83,7 @@ RUN echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" 
 WORKDIR ${HOME}
 USER ${USER_UID}
 
-COPY ansible-operator /usr/local/bin/ansible-operator
+ARG BUILD_DIR
+COPY ${BUILD_DIR}/ansible-operator /usr/local/bin/ansible-operator
 
 ENTRYPOINT ["/tini", "--", "/usr/local/bin/ansible-operator", "run", "--watches-file=./watches.yaml"]


### PR DESCRIPTION
When the guest and host OS are not same, the binary compiled and copied to the docker image fails to execute because of the incompatibility with executable format error. Hence, it is best to use a builder image as per the guest os to compile and use for building docker image.

<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**

The golang builder image is used to compile the ansible-operator as per the guest OS (linux) instead of host OS (darwin).

**Motivation for the change:**

The present image fails to execute the ansible-operator binary giving exec format error.

