### PR TITLE
Customizable e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -160,8 +160,12 @@ test-e2e-teardown: $(KIND)
 $(e2e_targets):: test-e2e-setup
 test-e2e:: $(e2e_tests) ## Run e2e tests
 
-test-e2e-ansible:: image/ansible-operator ## Run Ansible e2e tests
+test-e2e-ansible:: image/ansible-operator test-e2e-ansible-run ## Run Ansible e2e tests
+
+.PHONY: test-e2e-ansible-run
+test-e2e-ansible-run:
 	go test ./test/e2e/ansible -v -ginkgo.v
+
 test-e2e-ansible-molecule:: install dev-install image/ansible-operator ## Run molecule-based Ansible e2e tests
 	go run ./hack/generate/samples/molecule/generate.go
 	./hack/tests/e2e-ansible-molecule.sh

--- a/Makefile
+++ b/Makefile
@@ -166,8 +166,14 @@ test-e2e-ansible:: image/ansible-operator test-e2e-ansible-run ## Run Ansible e2
 test-e2e-ansible-run:
 	go test ./test/e2e/ansible -v -ginkgo.v
 
-test-e2e-ansible-molecule:: install dev-install image/ansible-operator ## Run molecule-based Ansible e2e tests
+test-e2e-ansible-molecule:: install dev-install image/ansible-operator test-e2e-ansible-molecule-generate test-e2e-ansible-molecule-run ## Run molecule-based Ansible e2e tests
+
+.PHONY: test-e2e-ansible-molecule-generate
+test-e2e-ansible-molecule-generate:
 	go run ./hack/generate/samples/molecule/generate.go
+
+.PHONY: test-e2e-ansible-molecule-run
+test-e2e-ansible-molecule-run:
 	./hack/tests/e2e-ansible-molecule.sh
 
 ## Location to install dependencies to

--- a/hack/generate/samples/ansible/constants.go
+++ b/hack/generate/samples/ansible/constants.go
@@ -518,6 +518,25 @@ const rolesForBaseOperator = `
       - watch
 #+kubebuilder:scaffold:rules
 `
+const rolesForProject = `
+  ##
+  ## Apply customize roles related to project.openshift.io
+  ##
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projectrequests
+      - projects
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+# +kubebuilder:scaffold:rules
+`
 
 const customMetricsTest = `
 - name: Search for all running pods

--- a/hack/generate/samples/ansible/memcached_molecule.go
+++ b/hack/generate/samples/ansible/memcached_molecule.go
@@ -40,12 +40,14 @@ func ImplementMemcachedMolecule(sample sample.Sample, image string) {
 			err := kbutil.InsertCode(moleculeTaskPath, targetMoleculeCheckDeployment, molecuTaskToCheckConfigMap)
 			pkg.CheckError("replacing memcached task to add config map check", err)
 
-			log.Info("insert molecule task to ensure to check secret")
-			err = kbutil.InsertCode(moleculeTaskPath, memcachedCustomStatusMoleculeTarget, testSecretMoleculeCheck)
-			pkg.CheckError("replacing memcached task to add secret check", err)
+			if skipSecretGeneration == "" {
+				log.Info("insert molecule task to ensure to check secret")
+				err = kbutil.InsertCode(moleculeTaskPath, memcachedCustomStatusMoleculeTarget, testSecretMoleculeCheck)
+				pkg.CheckError("replacing memcached task to add secret check", err)
+			}
 
 			log.Info("insert molecule task to ensure to foo ")
-			err = kbutil.InsertCode(moleculeTaskPath, testSecretMoleculeCheck, testFooMoleculeCheck)
+			err = kbutil.InsertCode(moleculeTaskPath, memcachedCustomStatusMoleculeTarget, testFooMoleculeCheck)
 			pkg.CheckError("replacing memcached task to add foo check", err)
 
 			log.Info("insert molecule task to check custom metrics")
@@ -98,35 +100,37 @@ func ImplementMemcachedMolecule(sample sample.Sample, image string) {
 		"playbook: playbooks/memcached.yml", memcachedWatchCustomizations)
 	pkg.CheckError("replacing in watches", err)
 
-	log.Info("removing ignore group for the secret from watches as an workaround to work with core types")
-	err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "watches.yaml"),
-		"ignore.example.com", "\"\"")
-	pkg.CheckError("replacing the watches file", err)
+	if skipSecretGeneration == "" {
+		log.Info("removing ignore group for the secret from watches as an workaround to work with core types")
+		err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "watches.yaml"),
+			"ignore.example.com", "\"\"")
+		pkg.CheckError("replacing the watches file", err)
 
-	log.Info("removing molecule test for the Secret since it is a core type")
-	cmd := exec.Command("rm", "-rf", filepath.Join(sample.Dir(), "molecule", "default", "tasks", "secret_test.yml"))
-	_, err = sample.CommandContext().Run(cmd)
-	pkg.CheckError("removing secret test file", err)
+		log.Info("removing molecule test for the Secret since it is a core type")
+		cmd := exec.Command("rm", "-rf", filepath.Join(sample.Dir(), "molecule", "default", "tasks", "secret_test.yml"))
+		_, err = sample.CommandContext().Run(cmd)
+		pkg.CheckError("removing secret test file", err)
 
-	log.Info("adding Secret task to the role")
-	err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "roles", "secret", "tasks", "main.yml"),
-		originalTaskSecret, taskForSecret)
-	pkg.CheckError("replacing in secret/tasks/main.yml file", err)
+		log.Info("adding Secret task to the role")
+		err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "roles", "secret", "tasks", "main.yml"),
+			originalTaskSecret, taskForSecret)
+		pkg.CheckError("replacing in secret/tasks/main.yml file", err)
 
-	log.Info("adding ManageStatus == false for role secret")
-	err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "watches.yaml"),
-		"role: secret", manageStatusFalseForRoleSecret)
-	pkg.CheckError("replacing in watches.yaml", err)
+		log.Info("adding ManageStatus == false for role secret")
+		err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "watches.yaml"),
+			"role: secret", manageStatusFalseForRoleSecret)
+		pkg.CheckError("replacing in watches.yaml", err)
 
-	// prevent high load of controller caused by watching all the secrets in the cluster
-	watchNamespacePatchFileName := "watch_namespace_patch.yaml"
-	log.Info("adding WATCH_NAMESPACE env patch to watch own namespace")
-	err = os.WriteFile(filepath.Join(sample.Dir(), "config", "testing", watchNamespacePatchFileName), []byte(watchNamespacePatch), 0644)
-	pkg.CheckError("adding watch_namespace_patch.yaml", err)
+		// prevent high load of controller caused by watching all the secrets in the cluster
+		watchNamespacePatchFileName := "watch_namespace_patch.yaml"
+		log.Info("adding WATCH_NAMESPACE env patch to watch own namespace")
+		err = os.WriteFile(filepath.Join(sample.Dir(), "config", "testing", watchNamespacePatchFileName), []byte(watchNamespacePatch), 0644)
+		pkg.CheckError("adding watch_namespace_patch.yaml", err)
 
-	log.Info("adding WATCH_NAMESPACE env patch to patch list to be applied")
-	err = kbutil.InsertCode(filepath.Join(sample.Dir(), "config", "testing", "kustomization.yaml"), "patches:",
-		fmt.Sprintf("\n- path: %s", watchNamespacePatchFileName))
-	pkg.CheckError("inserting in kustomization.yaml", err)
+		log.Info("adding WATCH_NAMESPACE env patch to patch list to be applied")
+		err = kbutil.InsertCode(filepath.Join(sample.Dir(), "config", "testing", "kustomization.yaml"), "patches:",
+			fmt.Sprintf("\n- path: %s", watchNamespacePatchFileName))
+		pkg.CheckError("inserting in kustomization.yaml", err)
+	}
 
 }

--- a/hack/generate/samples/ansible/memcached_molecule.go
+++ b/hack/generate/samples/ansible/memcached_molecule.go
@@ -57,6 +57,11 @@ func ImplementMemcachedMolecule(sample sample.Sample, image string) {
 			err = kbutil.InsertCode(filepath.Join(sample.Dir(), "roles", strings.ToLower(gvk.Kind), "tasks", "main.yml"),
 				roleFragment, memcachedWithBlackListTask)
 			pkg.CheckError("replacing in tasks/main.yml", err)
+
+			log.Info("adding RBAC permissions for project.openshift.io")
+			err = kbutil.ReplaceInFile(filepath.Join(sample.Dir(), "config", "rbac", "role.yaml"),
+				"# +kubebuilder:scaffold:rules", rolesForProject)
+			pkg.CheckError("replacing in role.yml", err)
 		}
 
 		if gvk.Kind != "Memcached" {

--- a/test/e2e/ansible/local_test.go
+++ b/test/e2e/ansible/local_test.go
@@ -15,6 +15,7 @@
 package e2e_ansible_test
 
 import (
+	"os"
 	"os/exec"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -24,19 +25,30 @@ import (
 
 var _ = Describe("Running Ansible projects", func() {
 	Context("built with operator-sdk", func() {
+		var (
+			skip_local_test string
+		)
 		BeforeEach(func() {
-			By("Installing CRD's")
-			err := operator.InstallCRDs(ansibleSample)
-			Expect(err).NotTo(HaveOccurred())
+			skip_local_test = os.Getenv(SKIP_LOCAL_TEST)
+			if skip_local_test == "" {
+				By("Installing CRD's")
+				err := operator.InstallCRDs(ansibleSample)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		})
 
 		AfterEach(func() {
-			By("Uninstalling CRD's")
-			err := operator.UninstallCRDs(ansibleSample)
-			Expect(err).NotTo(HaveOccurred())
+			if skip_local_test == "" {
+				By("Uninstalling CRD's")
+				err := operator.UninstallCRDs(ansibleSample)
+				Expect(err).NotTo(HaveOccurred())
+			}
 		})
 
 		It("Should run correctly when run locally", func() {
+			if skip_local_test != "" {
+				Skip("Skipping local test")
+			}
 			By("Running the project")
 			cmd := exec.Command("make", "run")
 			cmd.Dir = ansibleSample.Dir()

--- a/testdata/memcached-molecule-operator/config/rbac/role.yaml
+++ b/testdata/memcached-molecule-operator/config/rbac/role.yaml
@@ -107,6 +107,23 @@ rules:
       - watch
 
   ##
+  ## Apply customize roles related to project.openshift.io
+  ##
+  - apiGroups:
+      - project.openshift.io
+    resources:
+      - projectrequests
+      - projects
+    verbs:
+      - create
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+
+  ##
   ## Apply customize roles for base operator
   ##
   - apiGroups:
@@ -123,4 +140,5 @@ rules:
       - update
       - watch
 #+kubebuilder:scaffold:rules
+
 

--- a/testdata/memcached-molecule-operator/molecule/default/tasks/memcached_test.yml
+++ b/testdata/memcached-molecule-operator/molecule/default/tasks/memcached_test.yml
@@ -56,12 +56,6 @@
       resource_name=custom_resource.metadata.name
     )}}'
 
-# This will verify that the secret role was executed
-- name: Verify that test-service was created
-  assert:
-    that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
-
-
 - name: Verify that project testing-foo was created
   assert:
     that: lookup('k8s', kind='Namespace', api_version='v1', resource_name='testing-foo')
@@ -114,6 +108,12 @@
     that:
       - "'histogram_test_sum 2' in metrics_output.stdout"
 
+
+
+# This will verify that the secret role was executed
+- name: Verify that test-service was created
+  assert:
+    that: lookup('k8s', kind='Service', api_version='v1', namespace=namespace, resource_name='test-service')
 
 
 - when: molecule_yml.scenario.name == "test-local"


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
This PR adds the support of customizing the e2e tests by providing various inputs via environment variables. The behavior of the tests remains the same with the default values.

Following are the details of the changes:
- RBAC permissions were missing for operations related to `project.openshift.io`. Added them so that when the e2e test for memcached-molecule-operator is run on an OCP cluster the test passes successfully.
- An environment variable, `SKIP_SECRET_GENERATION`, is used to skip the generation of secret related testdata for memcached-molecule-operator. This variable can be used to generate the testdata when running the e2e test with memcached-molecule-operator on an OCP cluster. If not not skipped, the controller tries to reconcile all secrets from all namespaces which results in heavy load on the controller and the e2e test fails.
- Security context is added to the curl pod so that the creation of the pod doesn't fail on an OCP cluster.
- `MEMCACHED_MOLECULE_OPERATOR_IMAGE` environment variable is introduced which will hold the container image registry path for memcached-molecule-operator, if set. Local image will not be built when this variable is set.
- `SKIP_LOCAL_TEST` environment variable is introduced to skip the local test when it is set.
- `ADVANCED_MOLECULE_OPERATOR_IMAGE` environment variable is introduced which will hold the container image registry path for advanced-molecule-operator, if set. Local image will not be built when this variable is set. In addition to that, the Kind test for memcached-molecule-operator will be skipped.
- More granular Makefile targets are created so that only those can be called while skipping the targets which are related to Kind cluster creation.

**Motivation for the change:**

The e2e tests for ansible-operator-plugins are tightly coupled with Kind cluster. We want to use the same test cases that are used in the e2e tests on an OCP cluster. To enable us to do so, the e2e tests are needed to be made customizable so that they work on an OCP cluster, in addition to a Kind cluster.