### PR TITLE
add macOS and Windows build of ansible-operator

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -12,6 +12,8 @@ builds:
     mod_timestamp: "{{ .CommitTimestamp }}"
     goos:
     - linux
+    - darwin
+    - windows
     goarch:
     - amd64
     - arm64


### PR DESCRIPTION
For local development users are told to run the ansible-operator locally but there are no macOS and Windows builds for users of those environments. fixes #78
