### PR TITLE
Utilize GitHub Actions cache for image builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -13,8 +13,53 @@ on:
     - main
 
 jobs:
+  build-cache:
+    strategy:
+      matrix:
+        arch:
+          - amd64
+          - arm64
+          - ppc64le
+          - s390x
+        platform: [linux]
+    runs-on: ubuntu-latest
+    steps:
+    - name: Check out code into the Go module directory
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Install Go
+      uses: actions/setup-go@v4
+      with:
+        go-version-file: "go.mod"
+
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v2
+    
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+      # The Dockerfile expects that ansible-operator will be copied from the
+      # build context. We stub it here and then don't cache it. When Goreleaser
+      # runs, it should copy over the right file.
+    - name: Create ansible-operator stub
+      run: echo stubbed-in-ci >> ansible-operator
+
+    - name: Build
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        platforms: "${{ matrix.platform }}/${{ matrix.arch }}"
+        push: false
+        tags: "cache:${{ matrix.platform }}-${{ matrix.arch }}"
+        file: images/ansible-operator/Dockerfile
+        cache-from: type=gha,scope=${{ matrix.arch }}
+        cache-to: type=gha,mode=max,scope=${{ matrix.arch }}
+        no-cache-filters: final # don't cache this because the stubbed ansible-operator bin was copied in.
+
   goreleaser:
-    name: goreleaser
+    needs: [build-cache]
     runs-on: ubuntu-latest
     steps:
     - name: Check out code into the Go module directory
@@ -38,6 +83,10 @@ jobs:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v2
 
+    - name: Set up Docker Buildx
+      id: setup-buildx
+      uses: docker/setup-buildx-action@v3
+
     - name: Set the release related variables
       run: |
         if [[ $GITHUB_REF == refs/tags/* ]]; then
@@ -56,7 +105,13 @@ jobs:
           echo IMAGE_TAG="$(git describe --tags --always)" >> $GITHUB_ENV
         fi
 
+      # This gives us ACTIONS_RUNTIME_TOKEN and ACTIONS_CACHE_URL
+      # for use in goreleaser
+    - name: Expose GitHub Runtime
+      uses: crazy-max/ghaction-github-runtime@v3
+
     - name: Run goreleaser
       run: make release
       env:
         GITHUB_TOKEN: ${{ github.token }}
+        BUILDX_BUILDER: ${{ steps.setup-buildx.outputs.name }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -26,6 +26,9 @@ dockers:
   use: buildx
   build_flag_templates:
     - "--platform=linux/amd64"
+    - "--cache-from"
+    - "type=gha,scope=amd64,token={{ .Env.ACTIONS_RUNTIME_TOKEN }},url={{ .Env.ACTIONS_CACHE_URL }}"
+    - "--builder={{ .Env.BUILDX_BUILDER }}"
   extra_files:
     - "images/ansible-operator/Pipfile"
     - "images/ansible-operator/Pipfile.lock"
@@ -37,6 +40,9 @@ dockers:
   use: buildx
   build_flag_templates:
     - "--platform=linux/arm64"
+    - "--cache-from"
+    - "type=gha,scope=arm64,token={{ .Env.ACTIONS_RUNTIME_TOKEN }},url={{ .Env.ACTIONS_CACHE_URL }}"
+    - "--builder={{ .Env.BUILDX_BUILDER }}"
   extra_files:
     - "images/ansible-operator/Pipfile"
     - "images/ansible-operator/Pipfile.lock"
@@ -48,6 +54,9 @@ dockers:
   use: buildx
   build_flag_templates:
     - "--platform=linux/ppc64le"
+    - "--cache-from"
+    - "type=gha,scope=ppc64le,token={{ .Env.ACTIONS_RUNTIME_TOKEN }},url={{ .Env.ACTIONS_CACHE_URL }}"
+    - "--builder={{ .Env.BUILDX_BUILDER }}"
   extra_files:
     - "images/ansible-operator/Pipfile"
     - "images/ansible-operator/Pipfile.lock"
@@ -59,6 +68,9 @@ dockers:
   use: buildx
   build_flag_templates:
     - "--platform=linux/s390x"
+    - "--cache-from"
+    - "type=gha,scope=s390x,token={{ .Env.ACTIONS_RUNTIME_TOKEN }},url={{ .Env.ACTIONS_CACHE_URL }}"
+    - "--builder={{ .Env.BUILDX_BUILDER }}"
   extra_files:
     - "images/ansible-operator/Pipfile"
     - "images/ansible-operator/Pipfile.lock"

--- a/images/ansible-operator/Dockerfile
+++ b/images/ansible-operator/Dockerfile
@@ -40,7 +40,7 @@ RUN set -e && dnf clean all && rm -rf /var/cache/dnf/* \
   && dnf clean all \
   && rm -rf /var/cache/dnf
 
-FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1726694543 as base
+FROM registry.access.redhat.com/ubi9/ubi:9.4-1214.1726694543 AS base
 ARG TARGETARCH
 
 # Label this image with the repo and commit that built it, for freshmaking purposes.
@@ -68,7 +68,7 @@ RUN curl -L -o /tini https://github.com/krallin/tini/releases/download/${TINI_VE
   && chmod +x /tini && /tini --version
 
 # Final image.
-FROM base
+FROM base AS final
 
 ENV HOME=/opt/ansible \
     USER_NAME=ansible \


### PR DESCRIPTION
**Description of the change:**

- Add a cache-building phase of the release workflow, which uses [Docker's GitHub Actions cache backend](https://docs.docker.com/build/cache/backends/gha/) to cache images
- Modify the goreleaser configuration to leverage said cache when building images

**Motivation for the change:**

- The Release process has had issues completing from time to time, hitting long timeouts.

  - In doing a deep dive, I think the cause is either (a) storage on runners, or (b) CPU utilization. I can't really diagnose either reliably without running a self-hosted runner, and there's no guarantee that I can replicate.
  
  - We've seen build times of anywhere from 35 minutes, to as long as 4 hours (after I extended timeouts).

- The project is committed to Goreleaser as a release toolchain.

- If the image build task is separated from the goreleaser task, it stands to reason that most of our challenges will be alleviated, given that each architecture gets its own runner for the build phase.

**Alternatives considered:**

- I built a separate workflow that involved building the images in a matrix, and then just extracting the installed application and grafting it into the final container using Goreleaser. This is potentially a bit more reliable, but involves building a ton of Dockerfile fragments. It also makes building the image (say, on a workstation) much more challenging.

**Additional Benefit**

- If the layers are found in cache (e.g. if the changes being made don't change cached layers), the build times are _fast_. see: https://github.com/komish/ansible-operator-plugins/actions/runs/11281515689 (fully cached).
- This mostly keeps the Dockerfile intact. 

**Drawbacks:**

- The goreleaser file is now _very GitHub Actions centric_.