### PR TITLE
removing operator types from issues

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -30,14 +30,6 @@ Note: Make sure to first check the prerequisites that can be found in the main R
 
 #### Environment
 
-**Operator type:**
-
-<!-- Uncomment one or more of the following lines corresponding to the language of the operator type -->
-
-<!-- /language go -->
-<!-- /language ansible -->
-<!-- /language helm -->
-
 **Kubernetes cluster type:**
 
 <!-- The type of cluster used for testing/deployment, ex. "vanilla", "OpenShift" -->

--- a/.github/ISSUE_TEMPLATE/feature-request.md
+++ b/.github/ISSUE_TEMPLATE/feature-request.md
@@ -21,8 +21,3 @@ I have an issue when ...
 
 <!-- A clear and concise description of what you want to happen. Add any considered drawbacks. -->
 
-<!-- If your request relates to a particular operator type, uncomment one or more of the following lines corresponding to the language of that type -->
-
-<!-- /language go -->
-<!-- /language ansible -->
-<!-- /language helm -->

--- a/.github/ISSUE_TEMPLATE/support-question.md
+++ b/.github/ISSUE_TEMPLATE/support-question.md
@@ -40,14 +40,6 @@ We will try our best to answer the question, but we also have a mailing list and
 
 #### Environment
 
-**Operator type:**
-
-<!-- Uncomment one or more of the following lines corresponding to the language of the operator type -->
-
-<!-- /language go -->
-<!-- /language ansible -->
-<!-- /language helm -->
-
 **Kubernetes cluster type:**
 
 <!-- The type of cluster used for testing/deployment, ex. "vanilla", "OpenShift" -->


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
remove the operator type selections from this repo's issues templates

**Motivation for the change:**
everything in this repo is for the ansible operator type, so having a selection and the noise from the bot doesn't make sense.

