### PR TITLE
pin to go1.23.0 toolchain go1.23.4

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,8 @@
 module github.com/operator-framework/ansible-operator-plugins
 
-go 1.23.4
+go 1.23.0
+
+toolchain go1.23.4
 
 require (
 	github.com/go-logr/logr v1.4.2


### PR DESCRIPTION
**Description of the change:**

Modifies go.mod to pin to go1.23.0 with toolchain go1.23.4


**Motivation for the change:**

Downstream doesn't support go1.23.4 yet =S

