### PR TITLE
Remove `--ignore 70612` from  `pipenv check` in pipfile.Dockerfile

### DIFF
--- a/images/ansible-operator/pipfile.Dockerfile
+++ b/images/ansible-operator/pipfile.Dockerfile
@@ -26,7 +26,7 @@ RUN set -e && dnf clean all && rm -rf /var/cache/dnf/* \
   # NOTE: This ignored vulnerability (71064) was detected in requests, \
   # but the upgraded version doesn't support the use case (protocol we are using).\
   # Ref: https://github.com/operator-framework/ansible-operator-plugins/pull/67#issuecomment-2189164688
-  && pipenv check --ignore 70612 --ignore 71064 \
+  && pipenv check --ignore 71064 \
   && dnf remove -y gcc libffi-devel openssl-devel python3.12-devel \
   && dnf clean all \
   && rm -rf /var/cache/dnf


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
In https://github.com/operator-framework/ansible-operator-plugins/pull/126 PR, the vulnerability was fixed. So, there is no need to ignore it anymore.


**Motivation for the change:**
Stop ignoring already fixed vulnerability. 

