### PR TITLE
add back support for mac binaries for arm/amd

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -3,7 +3,7 @@ before:
     - go mod tidy
     - go mod download
 builds:
-  - id: binary
+  - id: linux-binary
     main: ./cmd/ansible-operator/
     binary: ansible-operator
     asmflags: "{{ .Env.GO_BUILD_ASMFLAGS }}"
@@ -17,6 +17,18 @@ builds:
     - arm64
     - ppc64le
     - s390x
+  - id: darwin-binary
+    main: ./cmd/ansible-operator/
+    binary: ansible-operator
+    asmflags: "{{ .Env.GO_BUILD_ASMFLAGS }}"
+    gcflags: "{{ .Env.GO_BUILD_GCFLAGS }}"
+    ldflags: "{{ .Env.GO_BUILD_LDFLAGS }}"
+    mod_timestamp: "{{ .CommitTimestamp }}"
+    goos:
+    - darwin
+    goarch:
+    - amd64
+    - arm64
 dockers:
 - image_templates:
   - "{{ .Env.IMAGE_REPO }}:{{ .Env.IMAGE_TAG }}-amd64"


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- Adding support back for mac (darwin) binaries

**Motivation for the change:**
- Fixes: #78 

