### PR TITLE
update controller code to account for V in GVK for watch resources

### DIFF
--- a/internal/ansible/controller/controller.go
+++ b/internal/ansible/controller/controller.go
@@ -92,7 +92,7 @@ func Add(mgr manager.Manager, options Options) *controller.Controller {
 	}
 
 	//Create new controller runtime controller and set the controller to watch GVK.
-	c, err := controller.New(fmt.Sprintf("%v-controller", strings.ToLower(options.GVK.Kind)), mgr,
+	c, err := controller.New(fmt.Sprintf("%v-%v-controller", strings.ToLower(options.GVK.Kind), strings.ToLower(options.GVK.Version)), mgr,
 		controller.Options{
 			Reconciler:              aor,
 			MaxConcurrentReconciles: options.MaxConcurrentReconciles,


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- update controller logic to take into account version in GroupVersionKind, to allow for multiple controller registrations for various versions of a CRD.

**Motivation for the change:**
- Fixes: #154 

**Testing:**
```
kubectl logs foo-operator-5dc78f4f54-trjhr
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"cmd","msg":"Version","Go Version":"go1.24.4","GOOS":"linux","GOARCH":"amd64","ansible-operator":"v1.39.0-10-g69eec07b-dirty","commit":"69eec07b3ae855719c1b0c32233aa83e16ae84b5"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"cmd","msg":"Environment variable OPERATOR_NAME has been deprecated, use --leader-election-id instead."}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"cmd","msg":"Watching all namespaces"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"watches","msg":"Environment variable not set; using default value","envVar":"ANSIBLE_VERBOSITY_FOO_EXAMPLE_COM","default":2}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"watches","msg":"Environment variable not set; using default value","envVar":"ANSIBLE_VERBOSITY_FOO_EXAMPLE_COM","default":2}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"ansible-controller","msg":"Watching resource","Options.Group":"example.com","Options.Version":"v1alpha1","Options.Kind":"Foo"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"ansible-controller","msg":"Watching resource","Options.Group":"example.com","Options.Version":"v1","Options.Kind":"Foo"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"proxy","msg":"Starting to serve","Address":"127.0.0.1:8888"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"apiserver","msg":"Starting to serve metrics listener","Address":"localhost:5050"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"controller-runtime.metrics","msg":"Starting metrics server"}
{"level":"info","ts":"2025-09-08T18:51:20Z","logger":"controller-runtime.metrics","msg":"Serving metrics server","bindAddress":":8443","secure":false}
{"level":"info","ts":"2025-09-08T18:51:20Z","msg":"starting server","name":"health probe","addr":"[::]:6789"}
{"level":"info","ts":"2025-09-08T18:51:20Z","msg":"Starting EventSource","controller":"foo-v1alpha1-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2025-09-08T18:51:20Z","msg":"Starting EventSource","controller":"foo-v1-controller","source":"kind source: *unstructured.Unstructured"}
{"level":"info","ts":"2025-09-08T18:51:21Z","msg":"Starting Controller","controller":"foo-v1alpha1-controller"}
{"level":"info","ts":"2025-09-08T18:51:21Z","msg":"Starting workers","controller":"foo-v1alpha1-controller","worker count":16}
{"level":"info","ts":"2025-09-08T18:51:21Z","msg":"Starting Controller","controller":"foo-v1-controller"}
{"level":"info","ts":"2025-09-08T18:51:21Z","msg":"Starting workers","controller":"foo-v1-controller","worker count":16}
```

