### PR TITLE
update to go 1.24.6 to address CVE-2025-47906 & CVE-2025-47907

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/ansible-operator-plugins
 
-go 1.24.4
+go 1.24.6
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
<!--

Welcome to the Operator SDK! Before contributing, make sure to:

- Read the contributing guidelines https://github.com/operator-framework/ansible-operator-plugins/blob/master/CONTRIBUTING.MD
- Rebase your branch on the latest upstream master
- Link any relevant issues, PR's, or documentation
- Check that the commit message is concice and helpful:
    - When fixing an issue, add "Closes #<ISSUE_NUMBER>"
    - Sign your commit https://github.com/apps/dco
- Follow the below checklist if making a user-facing change 

-->

**Description of the change:**
- Updating go version to `1.24.6` now that downstream has an available image

**Motivation for the change:**
- To address CVE's in the commit message
- Fixes: #173 


