### PR TITLE
(fix): skip special word handling when word is all uppercase

### DIFF
--- a/internal/ansible/paramconv/paramconv.go
+++ b/internal/ansible/paramconv/paramconv.go
@@ -124,8 +124,11 @@ func ToSnake(s string) string {
 	n := ""
 	iReal := -1
 
-	// append underscore (_) as prefix and postfix to isolate special words defined in the wordMapping
-	s = preprocessWordMapping(s)
+	// skip special word handling when entire string is all uppercase (no need to check lowercase since all special words are uppercased)
+	if strings.ToUpper(s) != s {
+		// append underscore (_) as prefix and postfix to isolate special words defined in the wordMapping
+		s = preprocessWordMapping(s)
+	}
 
 	for i, v := range s {
 		iReal++

--- a/internal/ansible/paramconv/paramconv_test.go
+++ b/internal/ansible/paramconv/paramconv_test.go
@@ -231,6 +231,11 @@ func TestToSnake(t *testing.T) {
 			args: args{"URLsegressIPsEgressHTTPs"},
 			want: "_urls_egress_ips_egress_https",
 		},
+		{
+			name: "should not interpret special word when entire word is uppercase",
+			args: args{"THIS_IS_SKIP_NOT_SK_IP"},
+			want: "_this_is_skip_not_sk_ip",
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
**Description of the change:**

Skip special word handling when string is entirely uppercase

**Motivation for the change:**

Partially fixes #192 


