### PR TITLE
Update Go version from 1.25.7 to 1.26.3 to address CVEs

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/ansible-operator-plugins
 
-go 1.26.1
+go 1.26.2
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/ansible-operator-plugins
 
-go 1.26.2
+go 1.26.3
 
 require (
 	github.com/go-logr/logr v1.4.3

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/operator-framework/ansible-operator-plugins
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/go-logr/logr v1.4.3


### PR DESCRIPTION
**This PR closes issues:** 

[CVE-2026-25679](https://github.com/advisories/GHSA-j3gx-2473-5fp8),
[CVE-2026-27139](https://github.com/advisories/GHSA-rv83-g57w-fr8j),
[CVE-2026-27142](https://github.com/advisories/GHSA-j4j7-vw47-rhfq),
[CVE-2026-32283](https://github.com/advisories/GHSA-jrg3-gfjw-hm96),
[CVE-2026-32280](https://github.com/advisories/GHSA-m4pr-4j3g-9v7v),
[CVE-2026-33811](https://github.com/advisories/GHSA-497x-jcxf-m478),
[CVE-2026-42499 ](https://github.com/advisories/GHSA-xq5j-9r39-c3vf),
[CVE-2026-27142](https://github.com/advisories/GHSA-j4j7-vw47-rhfq),
[CVE-2026-39836](https://github.com/advisories/GHSA-8g2r-hhvj-mv99),
CVE-2026-33814, 
[CVE-2026-39820](https://github.com/advisories/GHSA-p9h5-jm8x-mjm5)
**Description of the change:**
Updated the Go version from 1.25.7 to 1.26.3 in go.mod to use a more recent and secure Go toolchain.

**Motivation for the change:**
Fix multiple CVEs linked in the above issues

/cc [@chiragkyal](https://github.com/chiragkyal)
/cc [@acornett21](https://github.com/acornett21)
